### PR TITLE
Make DCO Verification optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Below is a sample leeroy config file:
 
     // Basic Auth for endoints
     "user": "USER",
-    "pass": "PASS"
+    "pass": "PASS",
+
+    // Whether DCO is required for builds to start.
+    "dco": true
 }
 ```
 

--- a/handlers.go
+++ b/handlers.go
@@ -128,19 +128,22 @@ func handlePullRequest(w http.ResponseWriter, r *http.Request) {
 		AuthToken: config.GHToken,
 		User:      config.GHUser,
 	}
-	valid, err := g.DcoVerified(prHook)
 
-	if err != nil {
-		log.Errorf("Error validating DCO: %v", err)
-		w.WriteHeader(500)
-		return
-	}
+	if config.DcoRequired {
+		valid, err := g.DcoVerified(prHook)
 
-	// DCO not valid, we don't start the build
-	if !valid {
-		log.Errorf("Invalid DCO for %s #%d. Aborting build", baseRepo, pr.Number)
-		w.WriteHeader(200)
-		return
+		if err != nil {
+			log.Errorf("Error validating DCO: %v", err)
+			w.WriteHeader(500)
+			return
+		}
+
+		// DCO not valid, we don't start the build
+		if !valid {
+			log.Errorf("Invalid DCO for %s #%d. Aborting build", baseRepo, pr.Number)
+			w.WriteHeader(200)
+			return
+		}
 	}
 
 	mergeable, err := g.IsMergeable(prHook)

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ type Config struct {
 	Builds       []Build        `json:"builds"`
 	User         string         `json:"user"`
 	Pass         string         `json:"pass"`
+	DcoRequired  bool           `json:"dco"`
 }
 
 type Build struct {


### PR DESCRIPTION
This adds the DCO verification as an option in the config.json. Very few projects require this.