### PR TITLE
Do not build PRs with only docs.

### DIFF
--- a/github/comments.go
+++ b/github/comments.go
@@ -8,7 +8,7 @@ import (
 	"github.com/crosbymichael/octokat"
 )
 
-func (g GitHub) addDCOUnsignedComment(repo octokat.Repo, pr *octokat.PullRequest, content *pullRequestContent) error {
+func (g GitHub) addDCOUnsignedComment(repo octokat.Repo, pr *PullRequest, content *pullRequestContent) error {
 	comment := `Please sign your commits following these rules:
 https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work
 The easiest way to do this is to amend the last commit:
@@ -89,7 +89,7 @@ Provide additional info you think is important:
 	return g.addUniqueComment(repo, strconv.Itoa(issueNum), comment, "#ENEEDMOREINFO", content)
 }
 
-func (g GitHub) removeComment(repo octokat.Repo, pr *octokat.PullRequest, commentType string, content *pullRequestContent) error {
+func (g GitHub) removeComment(repo octokat.Repo, commentType string, content *pullRequestContent) error {
 	if c := content.FindComment(commentType, g.User); c != nil {
 		return g.Client().RemoveComment(repo, c.Id)
 	}

--- a/github/mergeable.go
+++ b/github/mergeable.go
@@ -4,41 +4,31 @@ import (
 	"strconv"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/crosbymichael/octokat"
 )
 
-func (g GitHub) IsMergeable(prHook *octokat.PullRequestHook) (mergeable bool, err error) {
+func (g GitHub) IsMergeable(pr *PullRequest) (mergeable bool, err error) {
 	// assume the PR is mergable unless we specifically set to false
 	// because mergable true is equivalent to skip
 	mergeable = true
 
 	// we only want the prs that are opened/synchronized
-	if !prHook.IsOpened() && !prHook.IsSynchronize() {
+	if !pr.Hook.IsOpened() && !pr.Hook.IsSynchronize() {
 		return mergeable, nil
-	}
-
-	// get the PR
-	pr := prHook.PullRequest
-	repo := getRepo(prHook.Repo)
-
-	content, err := g.getContent(repo, prHook.Number, true)
-	if err != nil {
-		return mergeable, err
 	}
 
 	commentType := "merge conflicts"
 	if !isMergeable(pr) {
 		mergeable = false
-		log.Debugf("Found pr %d was not mergable, going to add comment", prHook.Number)
+		log.Debugf("Found pr %d was not mergable, going to add comment", pr.Hook.Number)
 
 		// add a comment
 		comment := "Looks like we would not be able to merge this PR because of merge conflicts. Please rebase, fix conflicts, and force push to your branch."
-		if err := g.addUniqueComment(repo, strconv.Itoa(prHook.Number), comment, commentType, content); err != nil {
+		if err := g.addUniqueComment(pr.Repo, strconv.Itoa(pr.Hook.Number), comment, commentType, pr.Content); err != nil {
 			return mergeable, err
 		}
 
 		// set the status
-		if err := g.failureStatus(repo, pr.Head.Sha, "docker/is-mergable", "This PR is not mergable, please fix conflicts.", "https://docs.docker.com/project/work-issue/"); err != nil {
+		if err := g.failureStatus(pr.Repo, pr.Head.Sha, "docker/is-mergable", "This PR is not mergable, please fix conflicts.", "https://docs.docker.com/project/work-issue/"); err != nil {
 			return mergeable, err
 		}
 
@@ -46,14 +36,14 @@ func (g GitHub) IsMergeable(prHook *octokat.PullRequestHook) (mergeable bool, er
 	}
 
 	// otherwise try to find the comment and remove it
-	if err := g.removeComment(repo, pr, commentType, content); err != nil {
+	if err := g.removeComment(pr.Repo, commentType, pr.Content); err != nil {
 		return mergeable, err
 	}
 
 	return mergeable, nil
 }
 
-func isMergeable(pr *octokat.PullRequest) bool {
+func isMergeable(pr *PullRequest) bool {
 	// this is kinda hacky because we made Mergeable a *bool
 	if pr.Mergeable != nil && *pr.Mergeable == false {
 		return false

--- a/github/mergeable_test.go
+++ b/github/mergeable_test.go
@@ -36,8 +36,10 @@ func TestIsMergeable(t *testing.T) {
 	}
 
 	for _, pe := range prs {
-		if pe.expected != isMergeable(pe.pr) {
-			t.Fatalf("expected %v, was %v, for: %#v\n", pe.expected, isMergeable(pe.pr), pe)
+		p := &PullRequest{PullRequest: pe.pr}
+		mergeable := isMergeable(p)
+		if pe.expected != mergeable {
+			t.Fatalf("expected %v, was %v, for: %#v\n", pe.expected, mergeable, pe)
 		}
 	}
 }

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -13,6 +13,34 @@ var (
 	dcoRegex = regexp.MustCompile("(?m)(Docker-DCO-1.1-)?Signed-off-by: ([^<]+) <([^<>@]+@[^<>]+)>( \\(github: ([a-zA-Z0-9][a-zA-Z0-9-]+)\\))?")
 )
 
+type PullRequest struct {
+	Hook    *octokat.PullRequestHook
+	Repo    octokat.Repo
+	Content *pullRequestContent
+	*octokat.PullRequest
+}
+
+func (g GitHub) LoadPullRequest(hook *octokat.PullRequestHook) (*PullRequest, error) {
+	pr := hook.PullRequest
+	repo := getRepo(hook.Repo)
+
+	content, err := g.getContent(repo, hook.Number, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PullRequest{
+		Hook:        hook,
+		Repo:        repo,
+		Content:     content,
+		PullRequest: pr,
+	}, nil
+}
+
+func (pr PullRequest) ReleaseBase() bool {
+	return pr.Base.Ref == "release"
+}
+
 type pullRequestContent struct {
 	id       int
 	files    []*octokat.PullRequestFile

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/jfrazelle/leeroy/jenkins"
+	"github.com/docker/leeroy/jenkins"
 )
 
 const (


### PR DESCRIPTION
- Avoid loading the PR content twice (reduce requests to the GitHub API)

Signed-off-by: David Calavera <david.calavera@gmail.com>