### PR TITLE
Move triage forward when maintainers comment on pull requests.

### DIFF
--- a/github/dco.go
+++ b/github/dco.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/crosbymichael/octokat"
 )
 
 const (
@@ -94,13 +93,6 @@ func (g GitHub) DcoVerified(pr *PullRequest) (bool, error) {
 	}
 
 	return verified, nil
-}
-
-func getRepo(repo *octokat.Repository) octokat.Repo {
-	return octokat.Repo{
-		Name:     repo.Name,
-		UserName: repo.Owner.Login,
-	}
 }
 
 func labelOs(pr *PullRequest, os string, fileChecker func() bool) bool {

--- a/github/github.go
+++ b/github/github.go
@@ -12,3 +12,14 @@ func (g GitHub) Client() *octokat.Client {
 	gh = gh.WithToken(g.AuthToken)
 	return gh
 }
+
+func nameWithOwner(repo *octokat.Repository) octokat.Repo {
+	return octokat.Repo{
+		Name:     repo.Name,
+		UserName: repo.Owner.Login,
+	}
+}
+
+func bot(user octokat.User) bool {
+	return user.Login == "GordonTheTurtle"
+}

--- a/github/issue.go
+++ b/github/issue.go
@@ -21,7 +21,7 @@ func (g GitHub) IssueInfoCheck(issueHook *octokat.IssueHook) error {
 	// docker info, docker version, uname -a
 	if !strings.Contains(body, "docker version") || !strings.Contains(body, "docker info") || !strings.Contains(body, "uname -a") {
 		// get content
-		repo := getRepo(issueHook.Repo)
+		repo := nameWithOwner(issueHook.Repo)
 		content, err := g.getContent(repo, issueHook.Issue.Number, false)
 		if err != nil {
 			return err
@@ -44,7 +44,7 @@ func (g GitHub) LabelIssueComment(issueHook *octokat.IssueHook) error {
 		"#mine":    "status/claimed",
 	}
 
-	repo := getRepo(issueHook.Repo)
+	repo := nameWithOwner(issueHook.Repo)
 
 	for token, label := range labelmap {
 		// if comment matches predefined actions AND author is not bot

--- a/github/labels.go
+++ b/github/labels.go
@@ -6,6 +6,12 @@ import (
 	"github.com/crosbymichael/octokat"
 )
 
+const (
+	triageLabel       = "status/0-triage"
+	designReviewLabel = "status/1-design-review"
+	codeReviewLabel   = "status/2-code-review"
+)
+
 type labels map[string]bool
 
 func (g GitHub) toggleLabels(repo octokat.Repo, issueNum int, labelToRemove, labelToAdd string) error {

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -22,7 +22,7 @@ type PullRequest struct {
 
 func (g GitHub) LoadPullRequest(hook *octokat.PullRequestHook) (*PullRequest, error) {
 	pr := hook.PullRequest
-	repo := getRepo(hook.Repo)
+	repo := nameWithOwner(hook.Repo)
 
 	content, err := g.getContent(repo, hook.Number, true)
 	if err != nil {

--- a/github/pull_request_review.go
+++ b/github/pull_request_review.go
@@ -1,0 +1,59 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/crosbymichael/octokat"
+)
+
+type PullRequestReviewCommentHook struct {
+	Action      string
+	PullRequest *octokat.PullRequest
+	Comment     *octokat.Comment
+	Repo        *octokat.Repository
+}
+
+func (pr PullRequestReviewCommentHook) IsOpen() bool {
+	return pr.PullRequest.State == "open"
+}
+
+func (g GitHub) MoveTriageForward(repo *octokat.Repository, number int, comment *octokat.Comment) error {
+	if !isMaintainer(comment.User) {
+		return nil
+	}
+
+	nwo := nameWithOwner(repo)
+
+	triage, err := g.labelExist(nwo, number, triageLabel)
+	if err != nil {
+		return err
+	}
+
+	if triage {
+		newLabel := designReviewLabel
+		if strings.TrimSpace(comment.Body) == "LGTM" {
+			newLabel = codeReviewLabel
+		}
+
+		if err := g.toggleLabels(nwo, number, triageLabel, newLabel); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ParsePullRequestReviewCommentHook(body io.Reader) (PullRequestReviewCommentHook, error) {
+	h := PullRequestReviewCommentHook{}
+	if err := json.NewDecoder(body).Decode(&h); err != nil {
+		return h, err
+	}
+
+	return h, nil
+}
+
+func isMaintainer(user octokat.User) bool {
+	return (user.Type == "Owner" || user.Type == "Collaborator") && !bot(user)
+}


### PR DESCRIPTION
Gordon will remove the label `status/0-triage` and add the label `status/1-design-review` as soon as a maintainer comments in a pull request.

Signed-off-by: David Calavera <david.calavera@gmail.com>