### PR TITLE
Collect +1 opinions in a single comment.

### DIFF
--- a/github/issue.go
+++ b/github/issue.go
@@ -1,10 +1,22 @@
 package github
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/crosbymichael/octokat"
+)
+
+const (
+	pollKey      = "USER POLL"
+	pollTemplate = `*USER POLL*
+
+*The best way to get notified when there are changes in this discussion is by clicking the Subscribe button in the top right.*
+
+The people listed below have appreciated your meaningfull discussion with a random +1:
+`
 )
 
 func (g GitHub) IssueInfoCheck(issueHook *octokat.IssueHook) error {
@@ -38,6 +50,14 @@ func (g GitHub) IssueInfoCheck(issueHook *octokat.IssueHook) error {
 }
 
 func (g GitHub) LabelIssueComment(issueHook *octokat.IssueHook) error {
+	if err := g.maybeClaimIssue(issueHook); err != nil {
+		return err
+	}
+
+	return g.maybeOpinion(issueHook)
+}
+
+func (g GitHub) maybeClaimIssue(issueHook *octokat.IssueHook) error {
 	var labelmap map[string]string = map[string]string{
 		"#dibs":    "status/claimed",
 		"#claimed": "status/claimed",
@@ -54,6 +74,62 @@ func (g GitHub) LabelIssueComment(issueHook *octokat.IssueHook) error {
 				return err
 			}
 			log.Infof("Added label %#v to issue %d", label, issueHook.Issue.Number)
+		}
+	}
+	return nil
+}
+
+func (g GitHub) maybeOpinion(issueHook *octokat.IssueHook) error {
+	body := strings.TrimSpace(issueHook.Comment.Body)
+
+	if body == "+1" {
+		login := issueHook.Comment.User.Login
+		commenters := map[string]int{login: issueHook.Comment.Id}
+
+		options := &octokat.Options{
+			QueryParams: map[string]string{"per_page": "100"},
+		}
+
+		repo := getRepo(issueHook.Repo)
+		issueId := strconv.Itoa(issueHook.Issue.Number)
+		comments, err := g.Client().Comments(repo, issueId, options)
+		if err != nil {
+			return err
+		}
+
+		var poll octokat.Comment
+
+		for _, c := range comments {
+			if strings.ToLower(c.User.Login) == g.User && strings.Contains(c.Body, pollKey) {
+				poll = c
+			} else if strings.TrimSpace(c.Body) == "+1" {
+				commenters[c.User.Login] = c.Id
+			}
+		}
+
+		if poll.Body != "" {
+			if !strings.Contains(poll.Body, login) {
+				for k, _ := range commenters {
+					poll.Body += fmt.Sprintf("\n@%s", k)
+				}
+				if _, err := g.Client().PatchComment(repo, strconv.Itoa(poll.Id), poll.Body); err != nil {
+					return err
+				}
+			}
+		} else {
+			tmpl := pollTemplate
+			for k, _ := range commenters {
+				tmpl += fmt.Sprintf("\n@%s", k)
+			}
+			if _, err := g.Client().AddComment(repo, issueId, tmpl); err != nil {
+				return err
+			}
+		}
+
+		for _, v := range commenters {
+			if err := g.Client().RemoveComment(repo, v); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
When someone comments with a simple +1, the bot will remove the comment
and add the user's login to a common comment with everyone else that
added a +1.

It inspects the issue looking for previously uncollected comments with
+1s and removes them too, so it works with comments that we already
have in opened issues.

Signed-off-by: David Calavera <david.calavera@gmail.com>