### PR TITLE
Add support for validating vendoring

### DIFF
--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -51,6 +51,21 @@ type pullRequestContent struct {
 	comments []octokat.Comment
 }
 
+func (p *pullRequestContent) HasVendoringChanges() bool {
+	if len(p.files) == 0 {
+		return false
+	}
+
+	// Did any files in the vendor dir change?
+	for _, f := range p.files {
+		if anyFolders(f.FileName, "vendor", "hack/vendor.sh", "hack/.vendor-helper.sh") {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (p *pullRequestContent) HasDocsChanges() bool {
 	if len(p.files) == 0 {
 		return false
@@ -196,6 +211,15 @@ func (g *GitHub) getContent(repo octokat.Repo, id int, isPR bool) (*pullRequestC
 		commits:  commits,
 		comments: comments,
 	}, nil
+}
+
+func anyFolders(fileName string, folders ...string) bool {
+	for _, f := range folders {
+		if strings.HasPrefix(fileName, f) {
+			return true
+		}
+	}
+	return false
 }
 
 func anyPackage(fileName string, packages ...string) bool {

--- a/handlers.go
+++ b/handlers.go
@@ -279,6 +279,16 @@ func handlePullRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// If there are vendoring changes validate them
+	if pullRequest.Content.HasVendoringChanges() {
+		build, err := config.getBuildByContextAndRepo("vendor", baseRepo)
+		if err != nil {
+			logrus.Warnf("Adding doc build to %s for %d failed: %v", baseRepo, pr.Number, err)
+		} else {
+			builds = append(builds, build)
+		}
+	}
+
 	// schedule the jenkins builds
 	for _, build := range builds {
 		if err := config.scheduleJenkinsBuild(baseRepo, pr.Number, build); err != nil {


### PR DESCRIPTION
Validation of vendoring are currently done using a script, during the build. 🐵

- This enables to run it in parallel of other builds (and speed up the main builds)
- This makes the main builds be green while waiting for changes to be vendored (for example with changes on engine-api). This way, we can demonstrate/discuss on design of a change before it is merged upstream — and all builds will be green except this one :angel: .

@calavera @jfrazelle wdyt ?

/cc @jfrazelle this would need a job just for that though :angel: 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>