### PR TITLE
Add version label to GitHub issue

### DIFF
--- a/github/issue.go
+++ b/github/issue.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -108,4 +109,17 @@ func (g GitHub) maybeOpinion(issueHook *octokat.IssueHook) error {
 	}
 
 	return nil
+}
+
+func (g GitHub) IssueAddVersionLabel(issueHook *octokat.IssueHook) error {
+	serverVersion := regexp.MustCompile(`Server:\s+Version:\s+(\d+\.\d+\.\d+)`)
+	versionSubmatch := serverVersion.FindStringSubmatch(issueHook.Issue.Body)
+	if len(versionSubmatch) < 2 {
+		return nil
+	}
+
+	// For a version `X.Y.Z`, add a label of the form `version/X.Y`.
+	version := versionSubmatch[1]
+	shortVersion := version[0:strings.LastIndex(version, ".")]
+	return g.addLabel(nameWithOwner(issueHook.Repo), issueHook.Issue.Number, "version/"+shortVersion)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -191,6 +191,13 @@ func handleIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Try to label the issue with the version information it contains.
+	if err := g.IssueAddVersionLabel(issueHook); err != nil {
+		logrus.Errorf("Error applying version label to issue: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+
 	// handle if it is an issue comment
 	// apply approproate labels
 	if err := g.LabelIssueComment(issueHook); err != nil {


### PR DESCRIPTION
When an issue containing version information is received, extract the
`x.y.z` version string and use it to label the issue with `version/x.y`.

Signed-off-by: Arnaud Porterie <arnaud.porterie@docker.com>