### PR TITLE
Update instructions for DCO sign-off

### DIFF
--- a/github/comments.go
+++ b/github/comments.go
@@ -14,7 +14,7 @@ https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work
 The easiest way to do this is to amend the last commit:
 ~~~console
 `
-	comment += fmt.Sprintf("$ git clone -b %q %s %s\n", pr.Head.Ref, pr.Head.Repo.SSHURL, "somewhere")
+	comment += fmt.Sprintf("$ git clone -b %q %s %s\n", pr.Head.Ref, pr.Head.Repo.CloneURL, "somewhere")
 	comment += "$ cd somewhere\n"
 
 	if pr.Commits > 1 {


### PR DESCRIPTION
The current instructions tell users to clone the repository using;

    git clone -b "my-pr" git@github.com:someone/docker.git somewhere

If the user doesn't have public-key authentication set up, this produces
an error;

    Permission denied (publickey).
    fatal: Could not read from remote repository.

    Please make sure you have the correct access rights
    and the repository exists

To prevent users from getting this error, change the instructions to
use the http clone URL instead;

    git clone -b "my-pr" https://github.com/someone/docker.git somewhere

