### PR TITLE
Remove exec driver deprecation warning

### DIFF
--- a/github/comments.go
+++ b/github/comments.go
@@ -36,12 +36,6 @@ Ammending updates the existing PR. You **DO NOT** need to open a new one.
 	return g.addUniqueComment(repo, strconv.Itoa(pr.Number), comment, "sign your commits", content)
 }
 
-func (g GitHub) addExecdriverDeprecationComment(repo octokat.Repo, pr *PullRequest, content *PullRequestContent) error {
-	comment := `Please note that concept of execdrivers is being replaced with OCI compliant binaries executed through containerd. There is an ongoing effort for switching to containerd in #20662 . Please consider porting the changes in your PR to this branch instead.`
-
-	return g.addUniqueComment(repo, strconv.Itoa(pr.Number), comment, "concept of execdrivers is being replaced with OCI compliant binaries", content)
-}
-
 func (g GitHub) removeComment(repo octokat.Repo, commentType string, content *PullRequestContent) error {
 	if c := content.FindComment(commentType, g.User); c != nil {
 		return g.Client().RemoveComment(repo, c.Id)

--- a/github/dco.go
+++ b/github/dco.go
@@ -97,14 +97,6 @@ func (g GitHub) DcoVerified(pr *PullRequest) (bool, error) {
 	return verified, nil
 }
 
-// CheckExecdriver checks if the pull request changes something in execdrivers
-func (g GitHub) CheckExecdriver(pr *PullRequest) error {
-	if pr.Execdriver() {
-		return g.addExecdriverDeprecationComment(pr.Repo, pr, pr.Content)
-	}
-	return g.removeComment(pr.Repo, "concept of execdrivers is being replaced with OCI compliant binaries", pr.Content)
-}
-
 func getRepo(repo *octokat.Repository) octokat.Repo {
 	return octokat.Repo{
 		Name:     repo.Name,

--- a/handlers.go
+++ b/handlers.go
@@ -265,12 +265,6 @@ func handlePullRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := g.CheckExecdriver(pullRequest); err != nil {
-		logrus.Errorf("Error checking execdriver: %v", err)
-		w.WriteHeader(500)
-		return
-	}
-
 	mergeable, err := g.IsMergeable(pullRequest)
 	if err != nil {
 		logrus.Errorf("Error checking if PR is mergeable: %v", err)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@calavera Noticed this was in there while correcting a typo in #64. Given it's now removed, no longer need to check.