### PR TITLE
Add support for starting pipeline jobs

### DIFF
--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -166,6 +166,33 @@ func (c *Client) BuildWithParameters(job string, parameters string) error {
 	return nil
 }
 
+// BuildPipeline is just BuildWithParameters but for a Pipeline job instead.
+func (c *Client) BuildPipeline(job string, prNumber int, prRef string) error {
+	subJobName := prRef
+	if prNumber != 0 {
+		subJobName = fmt.Sprintf("PR-%d", prNumber)
+	}
+	url := fmt.Sprintf("%s/job/%s/job/%s/build", c.Baseurl, job, subJobName)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte{}))
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth(c.Username, c.Token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 201 {
+		return fmt.Errorf("jenkins post to %s responded with status %d", url, resp.StatusCode)
+	}
+
+	return nil
+}
+
 // CancelBuildsForPR cancels any queued or running builds for a PR.
 func (c *Client) CancelBuildsForPR(job, pr string) error {
 	if env := os.Getenv("LEEROY_KEEP_OLD_BUILD_RUNNING"); env != "" {

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ type Build struct {
 	Context      string `json:"context"`
 	Custom       bool   `json:"custom"`
 	HandleIssues bool   `json:"handle_issues"`
+	IsPipeline   bool   `json:"is_pipeline"`
 }
 
 func init() {


### PR DESCRIPTION
Now that https://github.com/docker/containerd/pull/306 is merged, it may be necessary to restart a containerd job (or other future pipeline job) via leeroy. This changeset adds support for pipeline jobs to enable that.

Tested with a local Leeroy instance to start builds for containerd PR304 and master. Also made sure that non-pipeline builds can be started (tested with distribution PR1800).

Depends on https://github.com/crosbymichael/octokat/pull/18

This is probably the most substantial golang change I've ever submitted, so feel free to rip it apart and offer advice. Thanks!

/cc @thaJeztah @icecrime 