### PR TITLE
Remove `group/*` labels

### DIFF
--- a/github/dco.go
+++ b/github/dco.go
@@ -7,13 +7,6 @@ import (
 	"github.com/crosbymichael/octokat"
 )
 
-const (
-	groupWindows      = "group/windows"
-	groupFreeBSD      = "group/freebsd"
-	groupDistribution = "group/distribution"
-	groupProtobuf     = "group/protobuf"
-)
-
 // DcoVerified checks if the pull request has been properly signed
 func (g GitHub) DcoVerified(pr *PullRequest) (bool, error) {
 	// we only want the prs that are opened/synchronized
@@ -39,22 +32,6 @@ func (g GitHub) DcoVerified(pr *PullRequest) (bool, error) {
 		labels = []string{"status/3-docs-review"}
 	default:
 		labels = []string{"status/0-triage"}
-	}
-
-	if labelOs(pr, "windows", pr.Content.OnlyWindows) {
-		labels = append(labels, groupWindows)
-	}
-
-	if labelOs(pr, "freebsd", pr.Content.OnlyFreebsd) {
-		labels = append(labels, groupFreeBSD)
-	}
-
-	if labelOs(pr, "protobuf", pr.Content.Protobuf) {
-		labels = append(labels, groupProtobuf)
-	}
-
-	if pr.Content.Distribution() {
-		labels = append(labels, groupDistribution)
 	}
 
 	// add labels if there are any


### PR DESCRIPTION
Remove auto-labeling of groups, which has been removed from the
repository. Don't replace with anything else yet until the set of labels
stabilizes (and maybe we migrate off Leeroy).

Signed-off-by: Arnaud Porterie (icecrime) <arnaud.porterie@docker.com>